### PR TITLE
Stability tweaks

### DIFF
--- a/main.py
+++ b/main.py
@@ -190,7 +190,7 @@ class Program:
 
         if not opts.files:
             played = 0
-            click((0,0)) # Focus the window
+            click((1,1)) # Focus the window WITHOUT triggering the failsafe
             while played < opts.games or not opts.games:
                 if played:
                     log.info('Beginning new game...')

--- a/main.py
+++ b/main.py
@@ -190,6 +190,7 @@ class Program:
 
         if not opts.files:
             played = 0
+            click((0,0)) # Focus the window
             while played < opts.games or not opts.games:
                 if played:
                     log.info('Beginning new game...')

--- a/sigsolve/util.py
+++ b/sigsolve/util.py
@@ -111,10 +111,10 @@ def denumpify(array):
 
 
 def click(where, down=0.05, up=0):
-    x, y = where
-    pyautogui.mouseDown(x=x, y=y)
+    pyautogui.moveTo(*where)
+    pyautogui.mouseDown()
     time.sleep(down)
-    pyautogui.mouseUp(x=x, y=y)
+    pyautogui.mouseUp()
     time.sleep(up)
 
 


### PR DESCRIPTION
Issues fixed in this patch could cause marbles not to be clicked properly. This patch fixes the instability of the clicking mechanism, and focuses the window for the first game so as to not drop the first click.